### PR TITLE
Extension for Markdig

### DIFF
--- a/Milsymbol/Icons/ISymbolIconGenerator.cs
+++ b/Milsymbol/Icons/ISymbolIconGenerator.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Pmad.Milsymbol.Icons
+{
+    public interface ISymbolIconGenerator
+    {
+        List<SymbolIcon> Generate(IEnumerable<string> codes, SymbolIconOptions options);
+        SymbolIcon Generate(string sidc);
+        SymbolIcon Generate(string sidc, SymbolIconOptions options);
+    }
+}

--- a/Milsymbol/Icons/SymbolIconGenerator.cs
+++ b/Milsymbol/Icons/SymbolIconGenerator.cs
@@ -3,7 +3,7 @@ using Jint.Native;
 
 namespace Pmad.Milsymbol.Icons
 {
-    public class SymbolIconGenerator : IDisposable
+    public class SymbolIconGenerator : IDisposable, ISymbolIconGenerator
     {
         private readonly Engine engine;
         private readonly JsValue symbolFunction;

--- a/Pmad.Milsymbol.Markdig.Test/MilsymbolInlineParserTest.cs
+++ b/Pmad.Milsymbol.Markdig.Test/MilsymbolInlineParserTest.cs
@@ -12,7 +12,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]:";
+        var markdown = ":ms[10031000131211050000]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -27,7 +27,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[100310001312110500001234567890]:";
+        var markdown = ":ms[100310001312110500001234567890]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -42,7 +42,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[123]:";
+        var markdown = ":ms[123]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -56,7 +56,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[1003100013121105000X]:";
+        var markdown = ":ms[1003100013121105000X]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -70,7 +70,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000:";
+        var markdown = ":ms[10031000131211050000:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -84,7 +84,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]";
+        var markdown = ":ms[10031000131211050000]";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -98,7 +98,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = "milsymbol[10031000131211050000]:";
+        var markdown = "ms[10031000131211050000]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -126,7 +126,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[]:";
+        var markdown = ":ms[]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -134,13 +134,13 @@ public class MilsymbolInlineParserTest
     }
 
     [Fact]
-    public void Parser_EmptyOptions_ShouldParse()
+    public void Parser_NoOptions_ShouldParse()
     {
         var pipeline = new MarkdownPipelineBuilder()
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{}:";
+        var markdown = ":ms[10031000131211050000]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -149,13 +149,13 @@ public class MilsymbolInlineParserTest
     }
 
     [Fact]
-    public void Parser_MissingClosingBrace_ShouldNotParse()
+    public void Parser_MissingClosingBracket_WithOptions_ShouldNotParse()
     {
         var pipeline = new MarkdownPipelineBuilder()
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=50:";
+        var markdown = ":ms[10031000131211050000, size=50:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -169,7 +169,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=50}:";
+        var markdown = ":ms[10031000131211050000, size=50]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -184,7 +184,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=50, direction=45, strokeWidth=2.5}:";
+        var markdown = ":ms[10031000131211050000, size=50, direction=45, strokeWidth=2.5]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -201,7 +201,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{uniqueDesignation=\"A-1\"}:";
+        var markdown = ":ms[10031000131211050000, uniqueDesignation=\"A-1\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -216,7 +216,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{uniqueDesignation=\"Unit 1\", higherFormation=\"2BDE\", additionalInformation=\"Ready\"}:";
+        var markdown = ":ms[10031000131211050000, uniqueDesignation=\"Unit 1\", higherFormation=\"2BDE\", additionalInformation=\"Ready\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -233,7 +233,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=40, uniqueDesignation=\"A-1\"}:";
+        var markdown = ":ms[10031000131211050000, size=40, uniqueDesignation=\"A-1\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -249,7 +249,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{uniqueDesignation=\"A-1, Ready\"}:";
+        var markdown = ":ms[10031000131211050000, uniqueDesignation=\"A-1, Ready\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -264,7 +264,30 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=50, strokeWidth=2, outlineWidth=3, uniqueDesignation=\"A\", additionalInformation=\"B\", higherFormation=\"C\", commonIdentifier=\"D\", reinforcedReduced=\"E\", direction=90}:";
+        var markdown = ":ms[10031000131211050000, size=50, strokeWidth=2, outlineWidth=3, uniqueDesignation=\"A\", additionalInformation=\"B\", higherFormation=\"C\", commonIdentifier=\"D\", reinforcedReduced=\"E\", direction=90]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal(2, inline.Options.StrokeWidth);
+        Assert.Equal(3, inline.Options.OutlineWidth);
+        Assert.Equal("A", inline.Options.UniqueDesignation);
+        Assert.Equal("B", inline.Options.AdditionalInformation);
+        Assert.Equal("C", inline.Options.HigherFormation);
+        Assert.Equal("D", inline.Options.CommonIdentifier);
+        Assert.Equal("E", inline.Options.ReinforcedReduced);
+        Assert.Equal(90, inline.Options.Direction);
+    }
+
+    [Fact]
+    public void Parser_ShortOptionNames_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":ms[10031000131211050000, s=50, sw=2, ow=3, ud=\"A\", ai=\"B\", hf=\"C\", ci=\"D\", rr=\"E\", d=90]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -287,7 +310,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{invalidOption=test, size=40}:";
+        var markdown = ":ms[10031000131211050000, invalidOption=test, size=40]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -302,7 +325,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=invalid, uniqueDesignation=\"A-1\"}:";
+        var markdown = ":ms[10031000131211050000, size=invalid, uniqueDesignation=\"A-1\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -317,7 +340,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{SIZE=50, UniqueDesignation=\"A\"}:";
+        var markdown = ":ms[10031000131211050000, SIZE=50, UniqueDesignation=\"A\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -333,7 +356,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size = 50 , uniqueDesignation = \"A-1\" }:";
+        var markdown = ":ms[10031000131211050000, size = 50 , uniqueDesignation = \"A-1\" ]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -349,7 +372,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = "This is a symbol :milsymbol[10031000131211050000]: in a sentence.";
+        var markdown = "This is a symbol :ms[10031000131211050000]: in a sentence.";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -364,7 +387,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Symbol 1: :milsymbol[10031000131211050000]: and Symbol 2: :milsymbol[10061000161211000000]:.";
+        var markdown = "Symbol 1: :ms[10031000131211050000]: and Symbol 2: :ms[10061000161211000000]:.";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inlines = FindAllMilsymbolInlines(document);
@@ -396,7 +419,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol(defaultOptions: defaultOptions)
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]:";
+        var markdown = ":ms[10031000131211050000]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -421,7 +444,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol(defaultOptions: defaultOptions)
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{}:";
+        var markdown = ":ms[10031000131211050000]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -447,7 +470,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol(defaultOptions: defaultOptions)
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=120, uniqueDesignation=\"CUSTOM\"}:";
+        var markdown = ":ms[10031000131211050000, size=120, uniqueDesignation=\"CUSTOM\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -479,7 +502,43 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol(defaultOptions: defaultOptions)
             .Build();
 
-        var markdown = ":milsymbol[10031000131211050000]{size=50, strokeWidth=2, outlineWidth=1, direction=180, uniqueDesignation=\"A\", additionalInformation=\"B\", higherFormation=\"C\", commonIdentifier=\"D\", reinforcedReduced=\"E\"}:";
+        var markdown = ":ms[10031000131211050000, size=50, strokeWidth=2, outlineWidth=1, direction=180, uniqueDesignation=\"A\", additionalInformation=\"B\", higherFormation=\"C\", commonIdentifier=\"D\", reinforcedReduced=\"E\"]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal(2, inline.Options.StrokeWidth);
+        Assert.Equal(1, inline.Options.OutlineWidth);
+        Assert.Equal(180, inline.Options.Direction);
+        Assert.Equal("A", inline.Options.UniqueDesignation);
+        Assert.Equal("B", inline.Options.AdditionalInformation);
+        Assert.Equal("C", inline.Options.HigherFormation);
+        Assert.Equal("D", inline.Options.CommonIdentifier);
+        Assert.Equal("E", inline.Options.ReinforcedReduced);
+    }
+
+    [Fact]
+    public void Parser_AllOptionsOverriddenWithShortNames_ShouldNotUseDefaults()
+    {
+        var defaultOptions = new Icons.SymbolIconOptions
+        {
+            Size = 100,
+            StrokeWidth = 5,
+            OutlineWidth = 3,
+            Direction = 90,
+            UniqueDesignation = "DEFAULT-UD",
+            AdditionalInformation = "DEFAULT-AI",
+            HigherFormation = "DEFAULT-HF",
+            CommonIdentifier = "DEFAULT-CI",
+            ReinforcedReduced = "DEFAULT-RR"
+        };
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol(defaultOptions: defaultOptions)
+            .Build();
+
+        var markdown = ":ms[10031000131211050000, s=50, sw=2, ow=1, d=180, ud=\"A\", ai=\"B\", hf=\"C\", ci=\"D\", rr=\"E\"]:";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inline = FindMilsymbolInline(document);
@@ -508,7 +567,7 @@ public class MilsymbolInlineParserTest
             .UseMilsymbol(defaultOptions: defaultOptions)
             .Build();
 
-        var markdown = "Symbol 1: :milsymbol[10031000131211050000]: and Symbol 2: :milsymbol[10061000161211000000]{uniqueDesignation=\"B\"}:.";
+        var markdown = "Symbol 1: :ms[10031000131211050000]: and Symbol 2: :ms[10061000161211000000, uniqueDesignation=\"B\"]:.";
         var document = Markdown.Parse(markdown, pipeline);
         
         var inlines = FindAllMilsymbolInlines(document);

--- a/Pmad.Milsymbol.Markdig.Test/MilsymbolInlineParserTest.cs
+++ b/Pmad.Milsymbol.Markdig.Test/MilsymbolInlineParserTest.cs
@@ -1,0 +1,532 @@
+using Markdig;
+using Markdig.Syntax;
+
+namespace Pmad.Milsymbol.Markdig.Test;
+
+public class MilsymbolInlineParserTest
+{
+    [Fact]
+    public void Parser_ValidSimpleSyntax_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("10031000131211050000", inline!.Sidc);
+    }
+
+    [Fact]
+    public void Parser_ValidSidc30Digits_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[100310001312110500001234567890]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("100310001312110500001234567890", inline!.Sidc);
+    }
+
+    [Fact]
+    public void Parser_InvalidSidcLength_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[123]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_InvalidSidcCharacters_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[1003100013121105000X]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_MissingClosingBracket_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_MissingClosingColon_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_NotStartingWithColon_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "milsymbol[10031000131211050000]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_WrongPrefix_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":symbol[10031000131211050000]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_EmptySidc_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_EmptyOptions_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("10031000131211050000", inline!.Sidc);
+    }
+
+    [Fact]
+    public void Parser_MissingClosingBrace_ShouldNotParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=50:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.Null(inline);
+    }
+
+    [Fact]
+    public void Parser_SingleNumericOption_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=50}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+    }
+
+    [Fact]
+    public void Parser_MultipleNumericOptions_ShouldParseAll()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=50, direction=45, strokeWidth=2.5}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal(45, inline.Options.Direction);
+        Assert.Equal(2.5, inline.Options.StrokeWidth);
+    }
+
+    [Fact]
+    public void Parser_StringOption_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{uniqueDesignation=\"A-1\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("A-1", inline!.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_MultipleStringOptions_ShouldParseAll()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{uniqueDesignation=\"Unit 1\", higherFormation=\"2BDE\", additionalInformation=\"Ready\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("Unit 1", inline!.Options.UniqueDesignation);
+        Assert.Equal("2BDE", inline.Options.HigherFormation);
+        Assert.Equal("Ready", inline.Options.AdditionalInformation);
+    }
+
+    [Fact]
+    public void Parser_MixedOptions_ShouldParseAll()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=40, uniqueDesignation=\"A-1\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(40, inline!.Options.Size);
+        Assert.Equal("A-1", inline.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_OptionsWithCommaInQuotes_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{uniqueDesignation=\"A-1, Ready\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("A-1, Ready", inline!.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_AllSupportedOptions_ShouldParseAll()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=50, strokeWidth=2, outlineWidth=3, uniqueDesignation=\"A\", additionalInformation=\"B\", higherFormation=\"C\", commonIdentifier=\"D\", reinforcedReduced=\"E\", direction=90}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal(2, inline.Options.StrokeWidth);
+        Assert.Equal(3, inline.Options.OutlineWidth);
+        Assert.Equal("A", inline.Options.UniqueDesignation);
+        Assert.Equal("B", inline.Options.AdditionalInformation);
+        Assert.Equal("C", inline.Options.HigherFormation);
+        Assert.Equal("D", inline.Options.CommonIdentifier);
+        Assert.Equal("E", inline.Options.ReinforcedReduced);
+        Assert.Equal(90, inline.Options.Direction);
+    }
+
+    [Fact]
+    public void Parser_InvalidOptionName_ShouldIgnore()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{invalidOption=test, size=40}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(40, inline!.Options.Size);
+    }
+
+    [Fact]
+    public void Parser_InvalidNumericValue_ShouldIgnore()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=invalid, uniqueDesignation=\"A-1\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("A-1", inline!.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_CaseInsensitiveOptions_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{SIZE=50, UniqueDesignation=\"A\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal("A", inline.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_WhitespaceAroundEquals_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size = 50 , uniqueDesignation = \"A-1\" }:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal("A-1", inline.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_InSentence_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "This is a symbol :milsymbol[10031000131211050000]: in a sentence.";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal("10031000131211050000", inline!.Sidc);
+    }
+
+    [Fact]
+    public void Parser_MultipleSymbols_ShouldParseAll()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Symbol 1: :milsymbol[10031000131211050000]: and Symbol 2: :milsymbol[10061000161211000000]:.";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inlines = FindAllMilsymbolInlines(document);
+        Assert.Equal(2, inlines.Count);
+        Assert.Equal("10031000131211050000", inlines[0].Sidc);
+        Assert.Equal("10061000161211000000", inlines[1].Sidc);
+    }
+
+    [Fact]
+    public void OpeningCharacters_ShouldContainColon()
+    {
+        var parser = new MilsymbolInlineParser(new Icons.SymbolIconOptions());
+        
+        Assert.Contains(':', parser.OpeningCharacters!);
+    }
+
+    [Fact]
+    public void Parser_NoOptionsSpecified_ShouldUseDefaultOptions()
+    {
+        var defaultOptions = new Icons.SymbolIconOptions
+        {
+            Size = 100,
+            StrokeWidth = 5,
+            Direction = 180,
+            UniqueDesignation = "DEFAULT"
+        };
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol(defaultOptions: defaultOptions)
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(100, inline!.Options.Size);
+        Assert.Equal(5, inline.Options.StrokeWidth);
+        Assert.Equal(180, inline.Options.Direction);
+        Assert.Equal("DEFAULT", inline.Options.UniqueDesignation);
+    }
+
+    [Fact]
+    public void Parser_EmptyOptionsSpecified_ShouldUseDefaultOptions()
+    {
+        var defaultOptions = new Icons.SymbolIconOptions
+        {
+            Size = 75,
+            OutlineWidth = 2.5,
+            HigherFormation = "DEFAULT-HF"
+        };
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol(defaultOptions: defaultOptions)
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(75, inline!.Options.Size);
+        Assert.Equal(2.5, inline.Options.OutlineWidth);
+        Assert.Equal("DEFAULT-HF", inline.Options.HigherFormation);
+    }
+
+    [Fact]
+    public void Parser_PartialOptionsSpecified_ShouldMergeWithDefaults()
+    {
+        var defaultOptions = new Icons.SymbolIconOptions
+        {
+            Size = 80,
+            StrokeWidth = 3,
+            Direction = 45,
+            UniqueDesignation = "DEFAULT-UD",
+            HigherFormation = "DEFAULT-HF"
+        };
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol(defaultOptions: defaultOptions)
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=120, uniqueDesignation=\"CUSTOM\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(120, inline!.Options.Size);
+        Assert.Equal(3, inline.Options.StrokeWidth);
+        Assert.Equal(45, inline.Options.Direction);
+        Assert.Equal("CUSTOM", inline.Options.UniqueDesignation);
+        Assert.Equal("DEFAULT-HF", inline.Options.HigherFormation);
+    }
+
+    [Fact]
+    public void Parser_AllOptionsOverridden_ShouldNotUseDefaults()
+    {
+        var defaultOptions = new Icons.SymbolIconOptions
+        {
+            Size = 100,
+            StrokeWidth = 5,
+            OutlineWidth = 3,
+            Direction = 90,
+            UniqueDesignation = "DEFAULT-UD",
+            AdditionalInformation = "DEFAULT-AI",
+            HigherFormation = "DEFAULT-HF",
+            CommonIdentifier = "DEFAULT-CI",
+            ReinforcedReduced = "DEFAULT-RR"
+        };
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol(defaultOptions: defaultOptions)
+            .Build();
+
+        var markdown = ":milsymbol[10031000131211050000]{size=50, strokeWidth=2, outlineWidth=1, direction=180, uniqueDesignation=\"A\", additionalInformation=\"B\", higherFormation=\"C\", commonIdentifier=\"D\", reinforcedReduced=\"E\"}:";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inline = FindMilsymbolInline(document);
+        Assert.NotNull(inline);
+        Assert.Equal(50, inline!.Options.Size);
+        Assert.Equal(2, inline.Options.StrokeWidth);
+        Assert.Equal(1, inline.Options.OutlineWidth);
+        Assert.Equal(180, inline.Options.Direction);
+        Assert.Equal("A", inline.Options.UniqueDesignation);
+        Assert.Equal("B", inline.Options.AdditionalInformation);
+        Assert.Equal("C", inline.Options.HigherFormation);
+        Assert.Equal("D", inline.Options.CommonIdentifier);
+        Assert.Equal("E", inline.Options.ReinforcedReduced);
+    }
+
+    [Fact]
+    public void Parser_MultipleSymbolsWithDefaults_ShouldAllUseDefaults()
+    {
+        var defaultOptions = new Icons.SymbolIconOptions
+        {
+            Size = 60,
+            Direction = 270
+        };
+
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol(defaultOptions: defaultOptions)
+            .Build();
+
+        var markdown = "Symbol 1: :milsymbol[10031000131211050000]: and Symbol 2: :milsymbol[10061000161211000000]{uniqueDesignation=\"B\"}:.";
+        var document = Markdown.Parse(markdown, pipeline);
+        
+        var inlines = FindAllMilsymbolInlines(document);
+        Assert.Equal(2, inlines.Count);
+        Assert.Equal(60, inlines[0].Options.Size);
+        Assert.Equal(270, inlines[0].Options.Direction);
+        Assert.Equal(60, inlines[1].Options.Size);
+        Assert.Equal(270, inlines[1].Options.Direction);
+        Assert.Equal("B", inlines[1].Options.UniqueDesignation);
+    }
+
+    private static MilsymbolInline? FindMilsymbolInline(MarkdownDocument document)
+    {
+        return document.Descendants<MilsymbolInline>().FirstOrDefault();
+    }
+
+    private static List<MilsymbolInline> FindAllMilsymbolInlines(MarkdownDocument document)
+    {
+        return document.Descendants<MilsymbolInline>().ToList();
+    }
+}

--- a/Pmad.Milsymbol.Markdig.Test/MilsymbolMarkdownTest.cs
+++ b/Pmad.Milsymbol.Markdig.Test/MilsymbolMarkdownTest.cs
@@ -12,7 +12,7 @@ public class MilsymbolMarkdownTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = "This is a symbol: :milsymbol[10031000131211050000]: inline.";
+        var markdown = "This is a symbol: :ms[10031000131211050000]: inline.";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -26,7 +26,7 @@ public class MilsymbolMarkdownTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Symbol 1: :milsymbol[10031000131211050000]: and Symbol 2: :milsymbol[10061000161211000000]:.";
+        var markdown = "Symbol 1: :ms[10031000131211050000]: and Symbol 2: :ms[10061000161211000000]:.";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         var svgCount = System.Text.RegularExpressions.Regex.Matches(html, "<svg").Count;
@@ -40,11 +40,11 @@ public class MilsymbolMarkdownTest
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Invalid: :milsymbol[invalid]: symbol.";
+        var markdown = "Invalid: :ms[invalid]: symbol.";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.DoesNotContain("<svg", html);
-        Assert.Contains(":milsymbol[invalid]:", html);
+        Assert.Contains(":ms[invalid]:", html);
     }
 
     [Fact]
@@ -58,8 +58,8 @@ public class MilsymbolMarkdownTest
 
 This document shows military symbols:
 
-- Friend Infantry: :milsymbol[10031000131211050000]:
-- Enemy Armor: :milsymbol[10061000161211000000]:
+- Friend Infantry: :ms[10031000131211050000]:
+- Enemy Armor: :ms[10061000161211000000]:
 
 End of document.";
         
@@ -77,7 +77,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Large symbol: :milsymbol[10031000131211050000]{size=50}:";
+        var markdown = "Large symbol: :ms[10031000131211050000, size=50]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -91,7 +91,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Unit: :milsymbol[10031000131211050000]{uniqueDesignation=\"A-1\"}:";
+        var markdown = "Unit: :ms[10031000131211050000, uniqueDesignation=\"A-1\"]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -105,7 +105,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Unit: :milsymbol[10031000131211050000]{size=40, uniqueDesignation=\"B-2\", higherFormation=\"2BDE\"}:";
+        var markdown = "Unit: :ms[10031000131211050000, size=40, uniqueDesignation=\"B-2\", higherFormation=\"2BDE\"]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -120,7 +120,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Moving unit: :milsymbol[10031000131211050000]{direction=45}:";
+        var markdown = "Moving unit: :ms[10031000131211050000, direction=45]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -133,7 +133,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Info: :milsymbol[10031000131211050000]{additionalInformation=\"Ready\"}:";
+        var markdown = "Info: :ms[10031000131211050000, additionalInformation=\"Ready\"]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -141,13 +141,13 @@ End of document.";
     }
 
     [Fact]
-    public void MilsymbolInline_EmptyOptions_ShouldRenderNormally()
+    public void MilsymbolInline_NoOptions_ShouldRenderNormally()
     {
         var pipeline = new MarkdownPipelineBuilder()
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Empty options: :milsymbol[10031000131211050000]{}:";
+        var markdown = "No options: :ms[10031000131211050000]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -160,7 +160,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Quoted: :milsymbol[10031000131211050000]{uniqueDesignation=\"Alpha Company\"}:";
+        var markdown = "Quoted: :ms[10031000131211050000, uniqueDesignation=\"Alpha Company\"]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -174,7 +174,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Comma: :milsymbol[10031000131211050000]{uniqueDesignation=\"A-1, Ready\"}:";
+        var markdown = "Comma: :ms[10031000131211050000, uniqueDesignation=\"A-1, Ready\"]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);
@@ -188,7 +188,7 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Invalid: :milsymbol[10031000131211050000]{invalid:";
+        var markdown = "Invalid: :ms[10031000131211050000, invalid:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.DoesNotContain("<svg", html);
@@ -201,7 +201,21 @@ End of document.";
             .UseMilsymbol()
             .Build();
 
-        var markdown = "Mixed: :milsymbol[10031000131211050000]{size=40, invalidOption=test, uniqueDesignation=\"A-1\"}:";
+        var markdown = "Mixed: :ms[10031000131211050000, size=40, invalidOption=test, uniqueDesignation=\"A-1\"]:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("A-1", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_ShortOptionNames_ShouldRender()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Short: :ms[10031000131211050000, s=50, ud=\"A-1\"]:";
         var html = Markdown.ToHtml(markdown, pipeline);
 
         Assert.Contains("<svg", html);

--- a/Pmad.Milsymbol.Markdig.Test/MilsymbolMarkdownTest.cs
+++ b/Pmad.Milsymbol.Markdig.Test/MilsymbolMarkdownTest.cs
@@ -1,0 +1,210 @@
+using Markdig;
+using Pmad.Milsymbol.Markdig;
+
+namespace Pmad.Milsymbol.Markdig.Test;
+
+public class MilsymbolMarkdownTest
+{
+    [Fact]
+    public void MilsymbolInline_ShouldRenderSvg()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "This is a symbol: :milsymbol[10031000131211050000]: inline.";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("xmlns=\"http://www.w3.org/2000/svg\"", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_MultipleSymbols_ShouldRenderAll()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Symbol 1: :milsymbol[10031000131211050000]: and Symbol 2: :milsymbol[10061000161211000000]:.";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        var svgCount = System.Text.RegularExpressions.Regex.Matches(html, "<svg").Count;
+        Assert.Equal(2, svgCount);
+    }
+
+    [Fact]
+    public void MilsymbolInline_InvalidSidc_ShouldNotRender()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Invalid: :milsymbol[invalid]: symbol.";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.DoesNotContain("<svg", html);
+        Assert.Contains(":milsymbol[invalid]:", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_InParagraph_ShouldRender()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = @"# Military Symbols
+
+This document shows military symbols:
+
+- Friend Infantry: :milsymbol[10031000131211050000]:
+- Enemy Armor: :milsymbol[10061000161211000000]:
+
+End of document.";
+        
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("<h1>Military Symbols</h1>", html);
+        Assert.Contains("<li>Friend Infantry:", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_WithSize_ShouldRenderWithSize()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Large symbol: :milsymbol[10031000131211050000]{size=50}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        // The size affects the width/height attributes of the SVG
+    }
+
+    [Fact]
+    public void MilsymbolInline_WithUniqueDesignation_ShouldRenderWithText()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Unit: :milsymbol[10031000131211050000]{uniqueDesignation=\"A-1\"}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("A-1", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_WithMultipleOptions_ShouldRenderWithAllOptions()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Unit: :milsymbol[10031000131211050000]{size=40, uniqueDesignation=\"B-2\", higherFormation=\"2BDE\"}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("B-2", html);
+        Assert.Contains("2BDE", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_WithDirection_ShouldRenderWithDirection()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Moving unit: :milsymbol[10031000131211050000]{direction=45}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_WithAdditionalInformation_ShouldRenderWithText()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Info: :milsymbol[10031000131211050000]{additionalInformation=\"Ready\"}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("Ready", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_EmptyOptions_ShouldRenderNormally()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Empty options: :milsymbol[10031000131211050000]{}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_OptionsWithQuotedStrings_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Quoted: :milsymbol[10031000131211050000]{uniqueDesignation=\"Alpha Company\"}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("Alpha Company", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_OptionsWithCommaInQuotes_ShouldParse()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Comma: :milsymbol[10031000131211050000]{uniqueDesignation=\"A-1, Ready\"}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("A-1, Ready", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_InvalidOptionsFormat_ShouldNotRender()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Invalid: :milsymbol[10031000131211050000]{invalid:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.DoesNotContain("<svg", html);
+    }
+
+    [Fact]
+    public void MilsymbolInline_MixedValidAndInvalidOptions_ShouldRenderWithValidOnes()
+    {
+        var pipeline = new MarkdownPipelineBuilder()
+            .UseMilsymbol()
+            .Build();
+
+        var markdown = "Mixed: :milsymbol[10031000131211050000]{size=40, invalidOption=test, uniqueDesignation=\"A-1\"}:";
+        var html = Markdown.ToHtml(markdown, pipeline);
+
+        Assert.Contains("<svg", html);
+        Assert.Contains("A-1", html);
+    }
+}

--- a/Pmad.Milsymbol.Markdig.Test/Pmad.Milsymbol.Markdig.Test.csproj
+++ b/Pmad.Milsymbol.Markdig.Test/Pmad.Milsymbol.Markdig.Test.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+	
+	<ItemGroup>
+		<ProjectReference Include="..\Pmad.Milsymbol.Markdig\Pmad.Milsymbol.Markdig.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/Pmad.Milsymbol.Markdig/EXAMPLES.md
+++ b/Pmad.Milsymbol.Markdig/EXAMPLES.md
@@ -1,0 +1,154 @@
+﻿*# Milsymbol Markdown Examples
+
+This document demonstrates the various ways to use military symbols in Markdown.
+
+## Basic Usage
+
+Simple symbol without options:
+
+:milsymbol[10031000131211050000]:
+
+Multiple symbols in a sentence:
+The friendly forces :milsymbol[10031000131211050000]: engaged the enemy armor :milsymbol[10061000131205000051]: at grid 123456.
+
+## Size Options
+
+Small (20px):
+:milsymbol[10031000131211050000]{size=20}:
+
+Default:
+:milsymbol[10031000131211050000]:
+
+Medium (40px):
+:milsymbol[10031000131211050000]{size=40}:
+
+Large (60px):
+:milsymbol[10031000131211050000]{size=60}:
+
+## Text Labels
+
+### Unique Designation (Bottom Left Text)
+
+Unit identifier on top:
+:milsymbol[10031000131211050000]{uniqueDesignation="A-1"}:
+
+### Additional Information (Center Right Text)
+
+Status or additional info at bottom:
+:milsymbol[10031000131211050000]{additionalInformation="Ready"}:
+
+### Higher Formation (Bottom Right Text)
+
+Parent unit or formation:
+:milsymbol[10031000131211050000]{higherFormation="2BDE"}:
+
+### Common Identifier (Center Right Text)
+
+Common identifier or sequence:
+:milsymbol[10031000131211050000]{commonIdentifier="01"}:
+
+### Reinforced/Reduced Indicator
+
+Show unit strength modifier:
+:milsymbol[10031000131211050000]{reinforcedReduced="(+)"}:
+
+Reduced unit:
+:milsymbol[10031000131211050000]{reinforcedReduced="(-)"}:
+
+## Complete Unit Example
+
+Full unit with all text labels:
+:milsymbol[10031000131211050000]{uniqueDesignation="A-1", additionalInformation="Combat Ready", higherFormation="2BDE", commonIdentifier="01", reinforcedReduced="(+)"}:
+
+## Direction Arrows
+
+Unit moving East (90°):
+:milsymbol[10031000131211050000]{direction=90}:
+
+Unit moving North-East (45°):
+:milsymbol[10031000131211050000]{direction=45}:
+
+Unit moving North (0°):
+:milsymbol[10031000131211050000]{direction=0}:
+
+Unit moving South (180°):
+:milsymbol[10031000131211050000]{direction=180}:
+
+## Stroke and Outline Width
+
+Default stroke:
+:milsymbol[10031000131211050000]:
+
+Thicker stroke:
+:milsymbol[10031000131211050000]{strokeWidth=6}:
+
+With outline:
+:milsymbol[10031000131211050000]{outlineWidth=4}:
+
+Both customized:
+:milsymbol[10031000131211050000]{strokeWidth=6, outlineWidth=4}:
+
+## Practical Examples
+
+### Order of Battle (ORBAT)
+
+#### 2nd Brigade Combat Team
+
+- **Brigade HQ**: :milsymbol[10031000131211050000]{uniqueDesignation="2BCT", higherFormation="1DIV", size=40}:
+  - **Alpha Company**: :milsymbol[10031000131211050000]{uniqueDesignation="A", higherFormation="2BCT"}:
+    - 1st Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="A-1", higherFormation="ALPHA"}:
+    - 2nd Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="A-2", higherFormation="ALPHA"}:
+    - 3rd Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="A-3", higherFormation="ALPHA"}:
+  - **Bravo Company**: :milsymbol[10031000131211050000]{uniqueDesignation="B", higherFormation="2BCT"}:
+    - 1st Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="B-1", higherFormation="BRAVO"}:
+    - 2nd Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="B-2", higherFormation="BRAVO"}:
+
+### Situation Report (SITREP)
+
+Current positions as of 1200Z:
+
+| Unit | Status | Position | Symbol |
+|------|--------|----------|--------|
+| A-1 | Combat Ready | Grid 1234 | :milsymbol[10031000131211050000]{uniqueDesignation="A-1", additionalInformation="Ready"}: |
+| A-2 | Moving North | Grid 1235 | :milsymbol[10031000131211050000]{uniqueDesignation="A-2", direction=0}: |
+| B-1 | Reinforced | Grid 1244 | :milsymbol[10031000131211050000]{uniqueDesignation="B-1", reinforcedReduced="(+)"}: |
+| Enemy | Engaged | Grid 1300 | :milsymbol[10061000161211000000]{uniqueDesignation="HOSTILE", additionalInformation="Engaged"}: |
+
+### Movement Orders
+
+1. Alpha Company :milsymbol[10031000131211050000]{uniqueDesignation="A"}:
+   - Current: Grid 1234
+   - Move to: Grid 1300 :milsymbol[10031000131211050000]{uniqueDesignation="A", direction=45}:
+   - Status: Ready to move
+
+2. Bravo Company :milsymbol[10031000131211050000]{uniqueDesignation="B"}:
+   - Current: Grid 1244  
+   - Move to: Grid 1310 :milsymbol[10031000131211050000]{uniqueDesignation="B", direction=90}:
+   - Status: Awaiting orders
+
+## Different Symbol Types
+
+### Ground Units
+
+Infantry: :milsymbol[10031000131211050000]:
+Armor: :milsymbol[10031000131205000051]:
+Artillery: :milsymbol[10031000131303000000]:
+Aviation: :milsymbol[10030100001101000000]:
+
+### Hostile Forces
+
+Enemy Infantry: :milsymbol[10061000131211050000]:
+Enemy Armor: :milsymbol[10061000131205000051]:
+Enemy Artillery: :milsymbol[10061000131303000000]:
+
+### Neutral and Unknown
+
+Neutral: :milsymbol[10041000000000000000]:
+Unknown: :milsymbol[10011000000000000000]:
+
+## Notes
+
+- All text values with spaces must be in double quotes: `uniqueDesignation="A Company"`
+- Multiple options are separated by commas: `{size=40, uniqueDesignation="A-1"}`
+- Direction is in degrees (0=North, 90=East, 180=South, 270=West)
+- Empty options block `{}` is valid and renders with defaults

--- a/Pmad.Milsymbol.Markdig/EXAMPLES.md
+++ b/Pmad.Milsymbol.Markdig/EXAMPLES.md
@@ -1,4 +1,4 @@
-﻿*# Milsymbol Markdown Examples
+﻿# Milsymbol Markdown Examples
 
 This document demonstrates the various ways to use military symbols in Markdown.
 
@@ -6,87 +6,120 @@ This document demonstrates the various ways to use military symbols in Markdown.
 
 Simple symbol without options:
 
-:milsymbol[10031000131211050000]:
+:ms[10031000131211050000]:
 
 Multiple symbols in a sentence:
-The friendly forces :milsymbol[10031000131211050000]: engaged the enemy armor :milsymbol[10061000131205000051]: at grid 123456.
+The friendly forces :ms[10031000131211050000]: engaged the enemy armor :ms[10061000131205000051]: at grid 123456.
 
 ## Size Options
 
 Small (20px):
-:milsymbol[10031000131211050000]{size=20}:
+:ms[10031000131211050000, size=20]:
 
 Default:
-:milsymbol[10031000131211050000]:
+:ms[10031000131211050000]:
 
 Medium (40px):
-:milsymbol[10031000131211050000]{size=40}:
+:ms[10031000131211050000, size=40]:
 
 Large (60px):
-:milsymbol[10031000131211050000]{size=60}:
+:ms[10031000131211050000, size=60]:
+
+Using short syntax (s for size):
+:ms[10031000131211050000, s=60]:
 
 ## Text Labels
 
 ### Unique Designation (Bottom Left Text)
 
 Unit identifier on top:
-:milsymbol[10031000131211050000]{uniqueDesignation="A-1"}:
+:ms[10031000131211050000, uniqueDesignation="A-1"]:
+
+Using short syntax (ud):
+:ms[10031000131211050000, ud="A-1"]:
 
 ### Additional Information (Center Right Text)
 
 Status or additional info at bottom:
-:milsymbol[10031000131211050000]{additionalInformation="Ready"}:
+:ms[10031000131211050000, additionalInformation="Ready"]:
+
+Using short syntax (ai):
+:ms[10031000131211050000, ai="Ready"]:
 
 ### Higher Formation (Bottom Right Text)
 
 Parent unit or formation:
-:milsymbol[10031000131211050000]{higherFormation="2BDE"}:
+:ms[10031000131211050000, higherFormation="2BDE"]:
+
+Using short syntax (hf):
+:ms[10031000131211050000, hf="2BDE"]:
 
 ### Common Identifier (Center Right Text)
 
 Common identifier or sequence:
-:milsymbol[10031000131211050000]{commonIdentifier="01"}:
+:ms[10031000131211050000, commonIdentifier="01"]:
+
+Using short syntax (ci):
+:ms[10031000131211050000, ci="01"]:
 
 ### Reinforced/Reduced Indicator
 
 Show unit strength modifier:
-:milsymbol[10031000131211050000]{reinforcedReduced="(+)"}:
+:ms[10031000131211050000, reinforcedReduced="(+)"]:
+
+Using short syntax (rr):
+:ms[10031000131211050000, rr="(+)"]:
 
 Reduced unit:
-:milsymbol[10031000131211050000]{reinforcedReduced="(-)"}:
+:ms[10031000131211050000, rr="(-)"]:
 
 ## Complete Unit Example
 
-Full unit with all text labels:
-:milsymbol[10031000131211050000]{uniqueDesignation="A-1", additionalInformation="Combat Ready", higherFormation="2BDE", commonIdentifier="01", reinforcedReduced="(+)"}:
+Full unit with all text labels (long form):
+:ms[10031000131211050000, uniqueDesignation="A-1", additionalInformation="Combat Ready", higherFormation="2BDE", commonIdentifier="01", reinforcedReduced="(+)"]:
+
+Full unit with all text labels (short form):
+:ms[10031000131211050000, ud="A-1", ai="Combat Ready", hf="2BDE", ci="01", rr="(+)"]:
 
 ## Direction Arrows
 
 Unit moving East (90°):
-:milsymbol[10031000131211050000]{direction=90}:
+:ms[10031000131211050000, direction=90]:
+
+Using short syntax (d):
+:ms[10031000131211050000, d=90]:
 
 Unit moving North-East (45°):
-:milsymbol[10031000131211050000]{direction=45}:
+:ms[10031000131211050000, d=45]:
 
 Unit moving North (0°):
-:milsymbol[10031000131211050000]{direction=0}:
+:ms[10031000131211050000, d=0]:
 
 Unit moving South (180°):
-:milsymbol[10031000131211050000]{direction=180}:
+:ms[10031000131211050000, d=180]:
 
 ## Stroke and Outline Width
 
 Default stroke:
-:milsymbol[10031000131211050000]:
+:ms[10031000131211050000]:
 
 Thicker stroke:
-:milsymbol[10031000131211050000]{strokeWidth=6}:
+:ms[10031000131211050000, strokeWidth=6]:
+
+Using short syntax (sw):
+:ms[10031000131211050000, sw=6]:
 
 With outline:
-:milsymbol[10031000131211050000]{outlineWidth=4}:
+:ms[10031000131211050000, outlineWidth=4]:
+
+Using short syntax (ow):
+:ms[10031000131211050000, ow=4]:
 
 Both customized:
-:milsymbol[10031000131211050000]{strokeWidth=6, outlineWidth=4}:
+:ms[10031000131211050000, strokeWidth=6, outlineWidth=4]:
+
+Using short syntax:
+:ms[10031000131211050000, sw=6, ow=4]:
 
 ## Practical Examples
 
@@ -94,14 +127,14 @@ Both customized:
 
 #### 2nd Brigade Combat Team
 
-- **Brigade HQ**: :milsymbol[10031000131211050000]{uniqueDesignation="2BCT", higherFormation="1DIV", size=40}:
-  - **Alpha Company**: :milsymbol[10031000131211050000]{uniqueDesignation="A", higherFormation="2BCT"}:
-    - 1st Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="A-1", higherFormation="ALPHA"}:
-    - 2nd Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="A-2", higherFormation="ALPHA"}:
-    - 3rd Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="A-3", higherFormation="ALPHA"}:
-  - **Bravo Company**: :milsymbol[10031000131211050000]{uniqueDesignation="B", higherFormation="2BCT"}:
-    - 1st Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="B-1", higherFormation="BRAVO"}:
-    - 2nd Platoon: :milsymbol[10031000131211050000]{uniqueDesignation="B-2", higherFormation="BRAVO"}:
+- **Brigade HQ**: :ms[10031000131211050000, ud="2BCT", hf="1DIV", s=40]:
+  - **Alpha Company**: :ms[10031000131211050000, ud="A", hf="2BCT"]:
+    - 1st Platoon: :ms[10031000131211050000, ud="A-1", hf="ALPHA"]:
+    - 2nd Platoon: :ms[10031000131211050000, ud="A-2", hf="ALPHA"]:
+    - 3rd Platoon: :ms[10031000131211050000, ud="A-3", hf="ALPHA"]:
+  - **Bravo Company**: :ms[10031000131211050000, ud="B", hf="2BCT"]:
+    - 1st Platoon: :ms[10031000131211050000, ud="B-1", hf="BRAVO"]:
+    - 2nd Platoon: :ms[10031000131211050000, ud="B-2", hf="BRAVO"]:
 
 ### Situation Report (SITREP)
 
@@ -109,46 +142,61 @@ Current positions as of 1200Z:
 
 | Unit | Status | Position | Symbol |
 |------|--------|----------|--------|
-| A-1 | Combat Ready | Grid 1234 | :milsymbol[10031000131211050000]{uniqueDesignation="A-1", additionalInformation="Ready"}: |
-| A-2 | Moving North | Grid 1235 | :milsymbol[10031000131211050000]{uniqueDesignation="A-2", direction=0}: |
-| B-1 | Reinforced | Grid 1244 | :milsymbol[10031000131211050000]{uniqueDesignation="B-1", reinforcedReduced="(+)"}: |
-| Enemy | Engaged | Grid 1300 | :milsymbol[10061000161211000000]{uniqueDesignation="HOSTILE", additionalInformation="Engaged"}: |
+| A-1 | Combat Ready | Grid 1234 | :ms[10031000131211050000, ud="A-1", ai="Ready"]: |
+| A-2 | Moving North | Grid 1235 | :ms[10031000131211050000, ud="A-2", d=0]: |
+| B-1 | Reinforced | Grid 1244 | :ms[10031000131211050000, ud="B-1", rr="(+)"]: |
+| Enemy | Engaged | Grid 1300 | :ms[10061000161211000000, ud="HOSTILE", ai="Engaged"]: |
 
 ### Movement Orders
 
-1. Alpha Company :milsymbol[10031000131211050000]{uniqueDesignation="A"}:
+1. Alpha Company :ms[10031000131211050000, ud="A"]:
    - Current: Grid 1234
-   - Move to: Grid 1300 :milsymbol[10031000131211050000]{uniqueDesignation="A", direction=45}:
+   - Move to: Grid 1300 :ms[10031000131211050000, ud="A", d=45]:
    - Status: Ready to move
 
-2. Bravo Company :milsymbol[10031000131211050000]{uniqueDesignation="B"}:
+2. Bravo Company :ms[10031000131211050000, ud="B"]:
    - Current: Grid 1244  
-   - Move to: Grid 1310 :milsymbol[10031000131211050000]{uniqueDesignation="B", direction=90}:
+   - Move to: Grid 1310 :ms[10031000131211050000, ud="B", d=90]:
    - Status: Awaiting orders
 
 ## Different Symbol Types
 
 ### Ground Units
 
-Infantry: :milsymbol[10031000131211050000]:
-Armor: :milsymbol[10031000131205000051]:
-Artillery: :milsymbol[10031000131303000000]:
-Aviation: :milsymbol[10030100001101000000]:
+Infantry: :ms[10031000131211050000]:
+Armor: :ms[10031000131205000051]:
+Artillery: :ms[10031000131303000000]:
+Aviation: :ms[10030100001101000000]:
 
 ### Hostile Forces
 
-Enemy Infantry: :milsymbol[10061000131211050000]:
-Enemy Armor: :milsymbol[10061000131205000051]:
-Enemy Artillery: :milsymbol[10061000131303000000]:
+Enemy Infantry: :ms[10061000131211050000]:
+Enemy Armor: :ms[10061000131205000051]:
+Enemy Artillery: :ms[10061000131303000000]:
 
 ### Neutral and Unknown
 
-Neutral: :milsymbol[10041000000000000000]:
-Unknown: :milsymbol[10011000000000000000]:
+Neutral: :ms[10041000000000000000]:
+Unknown: :ms[10011000000000000000]:
+
+## Short Option Names Reference
+
+For more concise syntax, use these short names:
+
+- `s` = `size`
+- `sw` = `strokeWidth`
+- `ow` = `outlineWidth`
+- `ud` = `uniqueDesignation`
+- `ai` = `additionalInformation`
+- `hf` = `higherFormation`
+- `ci` = `commonIdentifier`
+- `rr` = `reinforcedReduced`
+- `d` = `direction`
 
 ## Notes
 
-- All text values with spaces must be in double quotes: `uniqueDesignation="A Company"`
-- Multiple options are separated by commas: `{size=40, uniqueDesignation="A-1"}`
+- All text values with spaces must be in double quotes: `ud="A Company"`
+- Multiple options are separated by commas: `:ms[SIDC, size=40, ud="A-1"]:`
 - Direction is in degrees (0=North, 90=East, 180=South, 270=West)
-- Empty options block `{}` is valid and renders with defaults
+- Options can use either long names or short names
+

--- a/Pmad.Milsymbol.Markdig/MarkdownPipelineBuilderExtensions.cs
+++ b/Pmad.Milsymbol.Markdig/MarkdownPipelineBuilderExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Markdig;
+using Pmad.Milsymbol.Icons;
+
+namespace Pmad.Milsymbol.Markdig;
+
+/// <summary>
+/// Extension methods for <see cref="MarkdownPipelineBuilder"/> to enable military symbol rendering.
+/// </summary>
+public static class MarkdownPipelineBuilderExtensions
+{
+    /// <summary>
+    /// Adds military symbol support to the Markdown pipeline.
+    /// This enables inline military symbols using the syntax: :milsymbol[SIDC]{options}:
+    /// </summary>
+    /// <param name="pipeline">The Markdown pipeline builder to extend.</param>
+    /// <param name="generator">Optional symbol icon generator. If null, a default <see cref="SymbolIconGenerator"/> will be used.</param>
+    /// <param name="defaultOptions">Optional default options for symbol rendering. If null, default <see cref="SymbolIconOptions"/> will be used.</param>
+    /// <returns>The same pipeline builder instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// var pipeline = new MarkdownPipelineBuilder()
+    ///     .UseMilsymbol()
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static MarkdownPipelineBuilder UseMilsymbol(this MarkdownPipelineBuilder pipeline, ISymbolIconGenerator? generator = null, SymbolIconOptions? defaultOptions = null)
+    {
+        pipeline.Extensions.Add(new MilsymbolExtension(
+            generator ?? new SymbolIconGenerator(),
+            defaultOptions ?? new SymbolIconOptions() { Size = 30 }));
+        return pipeline;
+    }
+}

--- a/Pmad.Milsymbol.Markdig/MilsymbolExtension.cs
+++ b/Pmad.Milsymbol.Markdig/MilsymbolExtension.cs
@@ -1,0 +1,54 @@
+using Markdig;
+using Markdig.Renderers;
+using Pmad.Milsymbol.Icons;
+
+namespace Pmad.Milsymbol.Markdig;
+
+/// <summary>
+/// A Markdig extension that adds support for military symbol rendering in Markdown.
+/// This extension registers the inline parser and HTML renderer needed to process military symbol syntax.
+/// </summary>
+public sealed class MilsymbolExtension : IMarkdownExtension
+{
+    private readonly ISymbolIconGenerator generator;
+    private readonly SymbolIconOptions defaultOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MilsymbolExtension"/> class.
+    /// </summary>
+    /// <param name="generator">The symbol icon generator used to create military symbol SVG markup.</param>
+    /// <param name="defaultOptions">The default options applied to all military symbols unless overridden.</param>
+    public MilsymbolExtension(ISymbolIconGenerator generator, SymbolIconOptions defaultOptions)
+    {
+        this.generator = generator;
+        this.defaultOptions = defaultOptions;
+    }
+
+    /// <summary>
+    /// Sets up the extension by registering the military symbol inline parser with the pipeline.
+    /// </summary>
+    /// <param name="pipeline">The Markdown pipeline builder to configure.</param>
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        if (!pipeline.InlineParsers.Contains<MilsymbolInlineParser>())
+        {
+            pipeline.InlineParsers.Add(new MilsymbolInlineParser(defaultOptions));
+        }
+    }
+
+    /// <summary>
+    /// Sets up the extension by registering the military symbol HTML renderer with the pipeline.
+    /// </summary>
+    /// <param name="pipeline">The Markdown pipeline.</param>
+    /// <param name="renderer">The renderer to configure. Only HTML renderers are supported.</param>
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+        if (renderer is HtmlRenderer htmlRenderer)
+        {
+            if (!htmlRenderer.ObjectRenderers.Contains<MilsymbolInlineRenderer>())
+            {
+                htmlRenderer.ObjectRenderers.Add(new MilsymbolInlineRenderer(generator));
+            }
+        }
+    }
+}

--- a/Pmad.Milsymbol.Markdig/MilsymbolInline.cs
+++ b/Pmad.Milsymbol.Markdig/MilsymbolInline.cs
@@ -1,0 +1,23 @@
+using Markdig.Syntax.Inlines;
+using Pmad.Milsymbol.Icons;
+
+namespace Pmad.Milsymbol.Markdig;
+
+/// <summary>
+/// Represents a military symbol inline element in the Markdown document.
+/// This is the AST (Abstract Syntax Tree) node created by <see cref="MilsymbolInlineParser"/> 
+/// and rendered by <see cref="MilsymbolInlineRenderer"/>.
+/// </summary>
+public sealed class MilsymbolInline : LeafInline
+{
+    /// <summary>
+    /// Gets or sets the SIDC (Symbol Identification Coding) code that identifies the military symbol.
+    /// Must be a 20 or 30 digit numeric string.
+    /// </summary>
+    public string Sidc { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Gets or sets the rendering options for the military symbol, such as size, stroke width, and text annotations.
+    /// </summary>
+    public SymbolIconOptions Options { get; set; } = new();
+}

--- a/Pmad.Milsymbol.Markdig/MilsymbolInlineParser.cs
+++ b/Pmad.Milsymbol.Markdig/MilsymbolInlineParser.cs
@@ -1,0 +1,327 @@
+using System.Globalization;
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Pmad.Milsymbol.Icons;
+
+namespace Pmad.Milsymbol.Markdig;
+
+/// <summary>
+/// Parses military symbol inline syntax in Markdown documents.
+/// Recognizes the syntax: :milsymbol[SIDC]{options}:
+/// where SIDC is a 20 or 30 digit code and options are optional key-value pairs.
+/// </summary>
+/// <example>
+/// Example usage in Markdown:
+/// <code>
+/// :milsymbol[10031000001211000000]:
+/// :milsymbol[10031000001211000000]{size=50, uniquedesignation="A-1"}:
+/// </code>
+/// </example>
+public sealed class MilsymbolInlineParser : InlineParser
+{
+    private readonly SymbolIconOptions defaultOptions;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MilsymbolInlineParser"/> class.
+    /// </summary>
+    /// <param name="defaultOptions">The default options to use for symbols when no options are specified.</param>
+    public MilsymbolInlineParser(SymbolIconOptions defaultOptions)
+    {
+        this.defaultOptions = defaultOptions;
+        OpeningCharacters = new[] { ':' };
+    }
+
+    /// <summary>
+    /// Attempts to match and parse a military symbol inline element from the current position in the Markdown text.
+    /// Expected format: :milsymbol[SIDC]{options}:
+    /// </summary>
+    /// <param name="processor">The inline processor managing the parsing state.</param>
+    /// <param name="slice">The current slice of text being parsed.</param>
+    /// <returns>True if a valid military symbol syntax was found and parsed; otherwise, false.</returns>
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        var startPosition = slice.Start;
+        var c = slice.CurrentChar;
+
+        if (c != ':')
+        {
+            return false;
+        }
+
+        // Save the start position
+        var start = slice.Start;
+        
+        // Move past the opening ':'
+        c = slice.NextChar();
+
+        // Check if it starts with 'milsymbol['
+        var match = "milsymbol[";
+        for (int i = 0; i < match.Length; i++)
+        {
+            if (slice.CurrentChar != match[i])
+            {
+                slice.Start = start;
+                return false;
+            }
+            slice.NextChar();
+        }
+
+        // Find the closing ']'
+        var sidcStart = slice.Start;
+        var sidcEnd = -1;
+
+        while (slice.CurrentChar != '\0')
+        {
+            if (slice.CurrentChar == ']')
+            {
+                sidcEnd = slice.Start;
+                break;
+            }
+            slice.NextChar();
+        }
+
+        if (sidcEnd == -1)
+        {
+            // No closing ']' found
+            slice.Start = start;
+            return false;
+        }
+
+        // Extract SIDC
+        var sidc = slice.Text.Substring(sidcStart, sidcEnd - sidcStart);
+        
+        // Validate SIDC format
+        if (!IsValidSidc(sidc))
+        {
+            slice.Start = start;
+            return false;
+        }
+
+        // Move past ']'
+        slice.NextChar();
+        
+        var options = defaultOptions;
+        
+        // Check for options syntax: '{' 
+        if (slice.CurrentChar == '{')
+        {
+            var optionsStart = slice.Start;
+            slice.NextChar(); // Move past '{'
+            
+            // Find the closing '}'
+            var optionsEnd = -1;
+            while (slice.CurrentChar != '\0')
+            {
+                if (slice.CurrentChar == '}')
+                {
+                    optionsEnd = slice.Start;
+                    slice.NextChar(); // Move past '}'
+                    break;
+                }
+                slice.NextChar();
+            }
+            
+            if (optionsEnd == -1)
+            {
+                // No closing '}' found, reset
+                slice.Start = start;
+                return false;
+            }
+            
+            var optionsText = slice.Text.Substring(optionsStart + 1, optionsEnd - optionsStart - 1);
+            options = ParseOptions(optionsText);
+        }
+        
+        // Expect closing ':'
+        if (slice.CurrentChar != ':')
+        {
+            slice.Start = start;
+            return false;
+        }
+        
+        var inline = new MilsymbolInline
+        {
+            Sidc = sidc,
+            Options = options,
+            Span = new global::Markdig.Syntax.SourceSpan(startPosition, slice.Start)
+        };
+        
+        processor.Inline = inline;
+        slice.NextChar(); // Move past the closing ':'
+        return true;
+    }
+
+    /// <summary>
+    /// Validates whether a string is a valid SIDC (Symbol Identification Coding) code.
+    /// </summary>
+    /// <param name="sidc">The string to validate.</param>
+    /// <returns>True if the SIDC is valid (20 or 30 numeric digits); otherwise, false.</returns>
+    private static bool IsValidSidc(string sidc)
+    {
+        if (string.IsNullOrWhiteSpace(sidc))
+        {
+            return false;
+        }
+
+        // SIDC should be 20 or 30 digits
+        if (sidc.Length != 20 && sidc.Length != 30)
+        {
+            return false;
+        }
+
+        // All characters should be digits
+        foreach (var c in sidc)
+        {
+            if (!char.IsDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    
+    /// <summary>
+    /// Parses the options string from the military symbol syntax.
+    /// Options are comma-separated key-value pairs (key=value).
+    /// String values can be enclosed in double quotes.
+    /// </summary>
+    /// <param name="optionsText">The options text to parse (without the surrounding braces).</param>
+    /// <returns>A <see cref="SymbolIconOptions"/> instance with parsed values merged with default options.</returns>
+    private SymbolIconOptions ParseOptions(string optionsText)
+    {
+        if (string.IsNullOrWhiteSpace(optionsText))
+        {
+            return defaultOptions;
+        }
+
+        var options = new SymbolIconOptions()
+        {
+            // Copy default options
+            Size = defaultOptions.Size,
+            StrokeWidth = defaultOptions.StrokeWidth,
+            OutlineWidth = defaultOptions.OutlineWidth,
+            UniqueDesignation = defaultOptions.UniqueDesignation,
+            AdditionalInformation = defaultOptions.AdditionalInformation,
+            HigherFormation = defaultOptions.HigherFormation,
+            CommonIdentifier = defaultOptions.CommonIdentifier,
+            ReinforcedReduced = defaultOptions.ReinforcedReduced,
+            Direction = defaultOptions.Direction,
+        };
+
+        // Split by comma, respecting quoted strings
+        var pairs = SplitOptions(optionsText);
+        
+        foreach (var pair in pairs)
+        {
+            var equalIndex = pair.IndexOf('=');
+            if (equalIndex <= 0)
+            {
+                continue;
+            }
+            
+            var key = pair.Substring(0, equalIndex).Trim();
+            var value = pair.Substring(equalIndex + 1).Trim();
+            
+            // Remove quotes if present
+            if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"')
+            {
+                value = value.Substring(1, value.Length - 2);
+            }
+            
+            switch (key.ToLowerInvariant())
+            {
+                case "size":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var size))
+                    {
+                        options.Size = size;
+                    }
+                    break;
+                    
+                case "strokewidth":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var strokeWidth))
+                    {
+                        options.StrokeWidth = strokeWidth;
+                    }
+                    break;
+                    
+                case "outlinewidth":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var outlineWidth))
+                    {
+                        options.OutlineWidth = outlineWidth;
+                    }
+                    break;
+                    
+                case "uniquedesignation":
+                    options.UniqueDesignation = value;
+                    break;
+                    
+                case "additionalinformation":
+                    options.AdditionalInformation = value;
+                    break;
+                    
+                case "higherformation":
+                    options.HigherFormation = value;
+                    break;
+                    
+                case "commonidentifier":
+                    options.CommonIdentifier = value;
+                    break;
+                    
+                case "reinforcedreduced":
+                    options.ReinforcedReduced = value;
+                    break;
+                    
+                case "direction":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var direction))
+                    {
+                        options.Direction = direction;
+                    }
+                    break;
+            }
+        }
+        
+        return options;
+    }
+    
+    /// <summary>
+    /// Splits the options text into individual key-value pair strings.
+    /// Respects quoted strings so that commas within quotes are not treated as separators.
+    /// </summary>
+    /// <param name="text">The options text to split.</param>
+    /// <returns>A list of individual option strings (key=value format).</returns>
+    private static List<string> SplitOptions(string text)
+    {
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+        
+        foreach (var c in text)
+        {
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                current.Append(c);
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                if (current.Length > 0)
+                {
+                    result.Add(current.ToString());
+                    current.Clear();
+                }
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+        
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString());
+        }
+        
+        return result;
+    }
+}

--- a/Pmad.Milsymbol.Markdig/MilsymbolInlineRenderer.cs
+++ b/Pmad.Milsymbol.Markdig/MilsymbolInlineRenderer.cs
@@ -1,0 +1,35 @@
+using Markdig.Renderers;
+using Markdig.Renderers.Html;
+using Pmad.Milsymbol.Icons;
+
+namespace Pmad.Milsymbol.Markdig;
+
+/// <summary>
+/// Renders <see cref="MilsymbolInline"/> elements to HTML by generating SVG military symbols.
+/// This renderer is responsible for converting the parsed military symbol AST nodes into actual SVG output.
+/// </summary>
+public sealed class MilsymbolInlineRenderer : HtmlObjectRenderer<MilsymbolInline>
+{
+    private readonly ISymbolIconGenerator generator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MilsymbolInlineRenderer"/> class.
+    /// </summary>
+    /// <param name="generator">The symbol icon generator used to create SVG military symbols.</param>
+    public MilsymbolInlineRenderer(ISymbolIconGenerator generator)
+    {
+        this.generator = generator;
+    }
+
+    /// <summary>
+    /// Renders the military symbol inline element to HTML.
+    /// Generates the SVG representation of the symbol and writes it to the output.
+    /// </summary>
+    /// <param name="renderer">The HTML renderer to write output to.</param>
+    /// <param name="obj">The military symbol inline element to render.</param>
+    protected override void Write(HtmlRenderer renderer, MilsymbolInline obj)
+    {
+        var symbol = generator.Generate(obj.Sidc, obj.Options);
+        renderer.Write(symbol.Svg);
+    }
+}

--- a/Pmad.Milsymbol.Markdig/Pmad.Milsymbol.Markdig.csproj
+++ b/Pmad.Milsymbol.Markdig/Pmad.Milsymbol.Markdig.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/jetelain/milsymbolsharp</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<Description>Markdig extension for military symbols (NATO APP-6D).</Description>
+		<IsAotCompatible>true</IsAotCompatible>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<Authors>Julien Etelain</Authors>
+
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Markdig" Version="0.44.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Milsymbol\Pmad.Milsymbol.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+</Project>

--- a/Pmad.Milsymbol.Markdig/QUICKREF.md
+++ b/Pmad.Milsymbol.Markdig/QUICKREF.md
@@ -1,0 +1,64 @@
+# Quick Reference
+
+## Basic Syntax
+
+```
+:milsymbol[SIDC]:
+```
+
+## With Options
+
+```
+:milsymbol[SIDC]{option1=value1, option2=value2}:
+```
+
+## Common Options Examples
+
+### Text Labels
+```markdown
+:milsymbol[10031000131211050000]{uniqueDesignation="A-1"}:
+:milsymbol[10031000131211050000]{additionalInformation="Ready"}:
+:milsymbol[10031000131211050000]{higherFormation="2BDE"}:
+:milsymbol[10031000131211050000]{commonIdentifier="01"}:
+:milsymbol[10031000131211050000]{reinforcedReduced="(+)"}:
+```
+
+### Size
+```markdown
+:milsymbol[10031000131211050000]{size=30}:
+:milsymbol[10031000131211050000]{size=50}:
+```
+
+### Direction
+```markdown
+:milsymbol[10031000131211050000]{direction=0}:    <!-- North -->
+:milsymbol[10031000131211050000]{direction=45}:   <!-- NE -->
+:milsymbol[10031000131211050000]{direction=90}:   <!-- East -->
+:milsymbol[10031000131211050000]{direction=180}:  <!-- South -->
+```
+
+### Combined
+```markdown
+:milsymbol[10031000131211050000]{uniqueDesignation="A-1", higherFormation="ALPHA", size=40}:
+:milsymbol[10031000131211050000]{uniqueDesignation="B-2", direction=45, additionalInformation="Moving"}:
+```
+
+## Common SIDC Examples
+
+| Description | SIDC | Markdown |
+|-------------|------|----------|
+| Friend Infantry | `10031000131211050000` | `:milsymbol[10031000131211050000]:` |
+| Friend Armor | `10031000161211000000` | `:milsymbol[10031000161211000000]:` |
+| Enemy Infantry | `10061000131211050000` | `:milsymbol[10061000131211050000]:` |
+| Enemy Armor | `10061000161211000000` | `:milsymbol[10061000161211000000]:` |
+| Neutral | `10041000131211050000` | `:milsymbol[10041000131211050000]:` |
+| Unknown | `10011000131211050000` | `:milsymbol[10011000131211050000]:` |
+
+## Tips
+
+- Use double quotes for strings with spaces: `uniqueDesignation="Alpha Company"`
+- Separate multiple options with commas
+- Numeric values don't need quotes: `size=40`
+- Direction is in degrees: 0=North, 90=East, 180=South, 270=West
+- Empty options `{}` is valid
+- Invalid SIDC or syntax will be left as plain text

--- a/Pmad.Milsymbol.Markdig/QUICKREF.md
+++ b/Pmad.Milsymbol.Markdig/QUICKREF.md
@@ -3,62 +3,103 @@
 ## Basic Syntax
 
 ```
-:milsymbol[SIDC]:
+:ms[SIDC]:
 ```
 
 ## With Options
 
 ```
-:milsymbol[SIDC]{option1=value1, option2=value2}:
+:ms[SIDC, option1=value1, option2=value2]:
 ```
+
+## Short Option Names
+
+| Long Name | Short | Description |
+|-----------|-------|-------------|
+| `size` | `s` | Symbol size |
+| `strokeWidth` | `sw` | Stroke width |
+| `outlineWidth` | `ow` | Outline width |
+| `uniqueDesignation` | `ud` | Unit designation |
+| `additionalInformation` | `ai` | Additional info |
+| `higherFormation` | `hf` | Higher formation |
+| `commonIdentifier` | `ci` | Common identifier |
+| `reinforcedReduced` | `rr` | Reinforced/reduced |
+| `direction` | `d` | Direction arrow |
 
 ## Common Options Examples
 
-### Text Labels
+### Text Labels (Long Form)
 ```markdown
-:milsymbol[10031000131211050000]{uniqueDesignation="A-1"}:
-:milsymbol[10031000131211050000]{additionalInformation="Ready"}:
-:milsymbol[10031000131211050000]{higherFormation="2BDE"}:
-:milsymbol[10031000131211050000]{commonIdentifier="01"}:
-:milsymbol[10031000131211050000]{reinforcedReduced="(+)"}:
+:ms[10031000131211050000, uniqueDesignation="A-1"]:
+:ms[10031000131211050000, additionalInformation="Ready"]:
+:ms[10031000131211050000, higherFormation="2BDE"]:
+:ms[10031000131211050000, commonIdentifier="01"]:
+:ms[10031000131211050000, reinforcedReduced="(+)"]:
+```
+
+### Text Labels (Short Form)
+```markdown
+:ms[10031000131211050000, ud="A-1"]:
+:ms[10031000131211050000, ai="Ready"]:
+:ms[10031000131211050000, hf="2BDE"]:
+:ms[10031000131211050000, ci="01"]:
+:ms[10031000131211050000, rr="(+)"]:
 ```
 
 ### Size
 ```markdown
-:milsymbol[10031000131211050000]{size=30}:
-:milsymbol[10031000131211050000]{size=50}:
+:ms[10031000131211050000, size=30]:
+:ms[10031000131211050000, size=50]:
+:ms[10031000131211050000, s=30]:
+:ms[10031000131211050000, s=50]:
 ```
 
 ### Direction
 ```markdown
-:milsymbol[10031000131211050000]{direction=0}:    <!-- North -->
-:milsymbol[10031000131211050000]{direction=45}:   <!-- NE -->
-:milsymbol[10031000131211050000]{direction=90}:   <!-- East -->
-:milsymbol[10031000131211050000]{direction=180}:  <!-- South -->
+:ms[10031000131211050000, direction=0]:    <!-- North -->
+:ms[10031000131211050000, direction=45]:   <!-- NE -->
+:ms[10031000131211050000, direction=90]:   <!-- East -->
+:ms[10031000131211050000, direction=180]:  <!-- South -->
+
+<!-- Or using short form: -->
+:ms[10031000131211050000, d=0]:    <!-- North -->
+:ms[10031000131211050000, d=45]:   <!-- NE -->
+:ms[10031000131211050000, d=90]:   <!-- East -->
+:ms[10031000131211050000, d=180]:  <!-- South -->
 ```
 
-### Combined
+### Combined (Long Form)
 ```markdown
-:milsymbol[10031000131211050000]{uniqueDesignation="A-1", higherFormation="ALPHA", size=40}:
-:milsymbol[10031000131211050000]{uniqueDesignation="B-2", direction=45, additionalInformation="Moving"}:
+:ms[10031000131211050000, uniqueDesignation="A-1", higherFormation="ALPHA", size=40]:
+:ms[10031000131211050000, uniqueDesignation="B-2", direction=45, additionalInformation="Moving"]:
+```
+
+### Combined (Short Form)
+```markdown
+:ms[10031000131211050000, ud="A-1", hf="ALPHA", s=40]:
+:ms[10031000131211050000, ud="B-2", d=45, ai="Moving"]:
 ```
 
 ## Common SIDC Examples
 
 | Description | SIDC | Markdown |
 |-------------|------|----------|
-| Friend Infantry | `10031000131211050000` | `:milsymbol[10031000131211050000]:` |
-| Friend Armor | `10031000161211000000` | `:milsymbol[10031000161211000000]:` |
-| Enemy Infantry | `10061000131211050000` | `:milsymbol[10061000131211050000]:` |
-| Enemy Armor | `10061000161211000000` | `:milsymbol[10061000161211000000]:` |
-| Neutral | `10041000131211050000` | `:milsymbol[10041000131211050000]:` |
-| Unknown | `10011000131211050000` | `:milsymbol[10011000131211050000]:` |
+| Friend Infantry | `10031000131211050000` | `:ms[10031000131211050000]:` |
+| Friend Armor | `10031000131205000051` | `:ms[10031000131205000051]:` |
+| Enemy Infantry | `10061000131211050000` | `:ms[10061000131211050000]:` |
+| Enemy Armor | `10061000131205000051` | `:ms[10061000131205000051]:` |
+| Neutral | `10041000000000000000` | `:ms[10041000000000000000]:` |
+| Unknown | `10011000000000000000` | `:ms[10011000000000000000]:` |
+
+Tools (based on Pmad.Milsymbol.AspNetCore) : 
+- Symbol creator : https://maps.plan-ops.fr/Symbols
+- All supported SIDC : https://maps.plan-ops.fr/Symbols/All
 
 ## Tips
 
-- Use double quotes for strings with spaces: `uniqueDesignation="Alpha Company"`
-- Separate multiple options with commas
-- Numeric values don't need quotes: `size=40`
+- Use double quotes for strings with spaces: `uniqueDesignation="Alpha Company"` or `ud="Alpha Company"`
+- Separate multiple options with commas: `:ms[SIDC, size=40, ud="A-1"]:`
+- Numeric values don't need quotes: `size=40` or `s=40`
 - Direction is in degrees: 0=North, 90=East, 180=South, 270=West
-- Empty options `{}` is valid
+- Use either long names or short names for options
 - Invalid SIDC or syntax will be left as plain text

--- a/Pmad.Milsymbol.Markdig/README.md
+++ b/Pmad.Milsymbol.Markdig/README.md
@@ -1,0 +1,139 @@
+# Pmad.Milsymbol.Markdig
+
+A Markdig extension that allows rendering military symbols (SVG) directly in Markdown documents.
+
+## Installation
+
+```bash
+dotnet add package Pmad.Milsymbol.Markdig
+```
+
+## Usage
+
+### Basic Setup
+
+```csharp
+using Markdig;
+using Pmad.Milsymbol.Markdig;
+
+var pipeline = new MarkdownPipelineBuilder()
+    .UseMilsymbol()
+    .Build();
+
+var markdown = "Friend Infantry: :milsymbol[10031000131211050000]:";
+var html = Markdown.ToHtml(markdown, pipeline);
+```
+
+### Custom Symbol Generator
+
+You can provide your own `SymbolIconGenerator` instance with custom settings:
+
+```csharp
+using Pmad.Milsymbol.Icons;
+using Markdig;
+using Pmad.Milsymbol.Markdig;
+
+var generator = new SymbolIconGenerator(SymbolStandard.App6d);
+var pipeline = new MarkdownPipelineBuilder()
+    .UseMilsymbol(generator)
+    .Build();
+
+var markdown = "Friend Infantry: :milsymbol[10031000131211050000]:";
+var html = Markdown.ToHtml(markdown, pipeline);
+```
+
+## Syntax
+
+The extension adds an inline syntax for military symbols:
+
+```
+:milsymbol[SIDC]:
+```
+
+Where `SIDC` is a valid Symbol Identification Code (20 or 30 digits).
+
+### Options Syntax
+
+You can specify rendering options using a key-value syntax:
+
+```
+:milsymbol[SIDC]{key1=value1, key2=value2}:
+```
+
+### Available Options
+
+| Option | Type | Description | Example |
+|--------|------|-------------|---------|
+| `size` | number | Size of the symbol | `size=50` |
+| `strokeWidth` | number | Width of symbol strokes | `strokeWidth=4` |
+| `outlineWidth` | number | Width of symbol outline | `outlineWidth=2` |
+| `uniqueDesignation` | string | Unit designation (top text) | `uniqueDesignation="A-1"` |
+| `additionalInformation` | string | Additional info (bottom text) | `additionalInformation="Ready"` |
+| `higherFormation` | string | Higher formation (top right) | `higherFormation="2BDE"` |
+| `commonIdentifier` | string | Common identifier (bottom right) | `commonIdentifier="01"` |
+| `reinforcedReduced` | string | Reinforced/reduced indicator | `reinforcedReduced="(+)"` |
+| `direction` | number | Direction arrow (degrees) | `direction=45` |
+
+**Note:** String values with spaces or special characters should be enclosed in double quotes.
+
+### Examples
+
+**Basic symbols:**
+```markdown
+# Military Symbols Demo
+
+This is a friend infantry unit: :milsymbol[10031000131211050000]:
+
+This is an enemy armor unit: :milsymbol[10061000161211000000]:
+
+You can use symbols inline in text, in lists:
+- Friend: :milsymbol[10031000131211050000]:
+- Enemy: :milsymbol[10061000161211000000]:
+
+Or in tables:
+| Unit | Symbol |
+|------|--------|
+| Infantry | :milsymbol[10031000131211050000]: |
+| Armor | :milsymbol[10061000161211000000]: |
+```
+
+**Symbols with options:**
+```markdown
+# Unit Roster
+
+## Alpha Company
+
+- **A-1 Platoon** (Ready): :milsymbol[10031000131211050000]{uniqueDesignation="A-1", additionalInformation="Ready", higherFormation="ALPHA"}:
+- **A-2 Platoon** (Moving NE): :milsymbol[10031000131211050000]{uniqueDesignation="A-2", direction=45}:
+- **Large symbol**: :milsymbol[10031000131211050000]{size=50, uniqueDesignation="HQ"}:
+
+## Bravo Company
+
+Enemy contact: :milsymbol[10061000161211000000]{uniqueDesignation="HOSTILE", additionalInformation="Engaged"}:
+```
+
+**Custom sizing:**
+```markdown
+Small: :milsymbol[10031000131211050000]{size=20}:
+Medium: :milsymbol[10031000131211050000]{size=30}:
+Large: :milsymbol[10031000131211050000]{size=50}:
+```
+
+## Features
+
+- Inline rendering of military symbols as SVG
+- Support for all APP-6D symbol codes (20 or 30 digits)
+- Full support for symbol rendering options (size, text labels, direction, etc.)
+- Works with standard Markdig pipeline
+- Thread-safe symbol generation
+- Invalid SIDC codes are left as-is in the output
+- Quoted string support for text options with spaces or special characters
+
+## SIDC Format
+
+The SIDC (Symbol Identification Code) must be:
+- 20 or 30 digits long
+- All numeric characters
+- A valid APP-6D symbol code
+
+For more information about SIDC codes, see the [main Pmad.Milsymbol documentation](../README.md).

--- a/Pmad.Milsymbol.Markdig/README.md
+++ b/Pmad.Milsymbol.Markdig/README.md
@@ -20,7 +20,7 @@ var pipeline = new MarkdownPipelineBuilder()
     .UseMilsymbol()
     .Build();
 
-var markdown = "Friend Infantry: :milsymbol[10031000131211050000]:";
+var markdown = "Friend Infantry: :ms[10031000131211050000]:";
 var html = Markdown.ToHtml(markdown, pipeline);
 ```
 
@@ -38,7 +38,7 @@ var pipeline = new MarkdownPipelineBuilder()
     .UseMilsymbol(generator)
     .Build();
 
-var markdown = "Friend Infantry: :milsymbol[10031000131211050000]:";
+var markdown = "Friend Infantry: :ms[10031000131211050000]:";
 var html = Markdown.ToHtml(markdown, pipeline);
 ```
 
@@ -47,34 +47,34 @@ var html = Markdown.ToHtml(markdown, pipeline);
 The extension adds an inline syntax for military symbols:
 
 ```
-:milsymbol[SIDC]:
+:ms[SIDC]:
 ```
 
 Where `SIDC` is a valid Symbol Identification Code (20 or 30 digits).
 
 ### Options Syntax
 
-You can specify rendering options using a key-value syntax:
+You can specify rendering options as comma-separated key-value pairs within the brackets:
 
 ```
-:milsymbol[SIDC]{key1=value1, key2=value2}:
+:ms[SIDC, key1=value1, key2=value2]:
 ```
 
 ### Available Options
 
-| Option | Type | Description | Example |
-|--------|------|-------------|---------|
-| `size` | number | Size of the symbol | `size=50` |
-| `strokeWidth` | number | Width of symbol strokes | `strokeWidth=4` |
-| `outlineWidth` | number | Width of symbol outline | `outlineWidth=2` |
-| `uniqueDesignation` | string | Unit designation (top text) | `uniqueDesignation="A-1"` |
-| `additionalInformation` | string | Additional info (bottom text) | `additionalInformation="Ready"` |
-| `higherFormation` | string | Higher formation (top right) | `higherFormation="2BDE"` |
-| `commonIdentifier` | string | Common identifier (bottom right) | `commonIdentifier="01"` |
-| `reinforcedReduced` | string | Reinforced/reduced indicator | `reinforcedReduced="(+)"` |
-| `direction` | number | Direction arrow (degrees) | `direction=45` |
+| Option | Short | Type | Description | Example |
+|--------|-------|------|-------------|---------|
+| `size` | `s` | number | Size of the symbol | `size=50` or `s=50` |
+| `strokeWidth` | `sw` | number | Width of symbol strokes | `strokeWidth=4` or `sw=4` |
+| `outlineWidth` | `ow` | number | Width of symbol outline | `outlineWidth=2` or `ow=2` |
+| `uniqueDesignation` | `ud` | string | Unit designation (top text) | `uniqueDesignation="A-1"` or `ud="A-1"` |
+| `additionalInformation` | `ai` | string | Additional info (bottom text) | `additionalInformation="Ready"` or `ai="Ready"` |
+| `higherFormation` | `hf` | string | Higher formation (top right) | `higherFormation="2BDE"` or `hf="2BDE"` |
+| `commonIdentifier` | `ci` | string | Common identifier (bottom right) | `commonIdentifier="01"` or `ci="01"` |
+| `reinforcedReduced` | `rr` | string | Reinforced/reduced indicator | `reinforcedReduced="(+)"` or `rr="(+)"` |
+| `direction` | `d` | number | Direction arrow (degrees) | `direction=45` or `d=45` |
 
-**Note:** String values with spaces or special characters should be enclosed in double quotes.
+**Note:** String values with spaces or special characters should be enclosed in double quotes. Both long and short option names can be used interchangeably.
 
 ### Examples
 
@@ -82,41 +82,61 @@ You can specify rendering options using a key-value syntax:
 ```markdown
 # Military Symbols Demo
 
-This is a friend infantry unit: :milsymbol[10031000131211050000]:
+This is a friend infantry unit: :ms[10031000131211050000]:
 
-This is an enemy armor unit: :milsymbol[10061000161211000000]:
+This is an enemy armor unit: :ms[10061000161211000000]:
 
 You can use symbols inline in text, in lists:
-- Friend: :milsymbol[10031000131211050000]:
-- Enemy: :milsymbol[10061000161211000000]:
+- Friend: :ms[10031000131211050000]:
+- Enemy: :ms[10061000161211000000]:
 
 Or in tables:
 | Unit | Symbol |
 |------|--------|
-| Infantry | :milsymbol[10031000131211050000]: |
-| Armor | :milsymbol[10061000161211000000]: |
+| Infantry | :ms[10031000131211050000]: |
+| Armor | :ms[10061000161211000000]: |
 ```
 
-**Symbols with options:**
+**Symbols with options (long form):**
 ```markdown
 # Unit Roster
 
 ## Alpha Company
 
-- **A-1 Platoon** (Ready): :milsymbol[10031000131211050000]{uniqueDesignation="A-1", additionalInformation="Ready", higherFormation="ALPHA"}:
-- **A-2 Platoon** (Moving NE): :milsymbol[10031000131211050000]{uniqueDesignation="A-2", direction=45}:
-- **Large symbol**: :milsymbol[10031000131211050000]{size=50, uniqueDesignation="HQ"}:
+- **A-1 Platoon** (Ready): :ms[10031000131211050000, uniqueDesignation="A-1", additionalInformation="Ready", higherFormation="ALPHA"]:
+- **A-2 Platoon** (Moving NE): :ms[10031000131211050000, uniqueDesignation="A-2", direction=45]:
+- **Large symbol**: :ms[10031000131211050000, size=50, uniqueDesignation="HQ"]:
 
 ## Bravo Company
 
-Enemy contact: :milsymbol[10061000161211000000]{uniqueDesignation="HOSTILE", additionalInformation="Engaged"}:
+Enemy contact: :ms[10061000161211000000, uniqueDesignation="HOSTILE", additionalInformation="Engaged"]:
+```
+
+**Symbols with options (short form):**
+```markdown
+# Unit Roster
+
+## Alpha Company
+
+- **A-1 Platoon** (Ready): :ms[10031000131211050000, ud="A-1", ai="Ready", hf="ALPHA"]:
+- **A-2 Platoon** (Moving NE): :ms[10031000131211050000, ud="A-2", d=45]:
+- **Large symbol**: :ms[10031000131211050000, s=50, ud="HQ"]:
+
+## Bravo Company
+
+Enemy contact: :ms[10061000161211000000, ud="HOSTILE", ai="Engaged"]:
 ```
 
 **Custom sizing:**
 ```markdown
-Small: :milsymbol[10031000131211050000]{size=20}:
-Medium: :milsymbol[10031000131211050000]{size=30}:
-Large: :milsymbol[10031000131211050000]{size=50}:
+Small: :ms[10031000131211050000, size=20]:
+Medium: :ms[10031000131211050000, size=30]:
+Large: :ms[10031000131211050000, size=50]:
+
+Or using short form:
+Small: :ms[10031000131211050000, s=20]:
+Medium: :ms[10031000131211050000, s=30]:
+Large: :ms[10031000131211050000, s=50]:
 ```
 
 ## Features

--- a/Pmad.Milsymbol.sln
+++ b/Pmad.Milsymbol.sln
@@ -28,6 +28,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Github", "Github", "{02EA68
 		.github\workflows\dotnet-linux.yml = .github\workflows\dotnet-linux.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pmad.Milsymbol.Markdig", "Pmad.Milsymbol.Markdig\Pmad.Milsymbol.Markdig.csproj", "{6F050DC6-8A35-4577-88DF-99F9193734D4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pmad.Milsymbol.Markdig.Test", "Pmad.Milsymbol.Markdig.Test\Pmad.Milsymbol.Markdig.Test.csproj", "{F920BC5A-9BBF-40D4-BAAF-C22ADE187D12}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +66,14 @@ Global
 		{B72A78F3-F7EA-4B4F-9BD3-252F198BF48E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B72A78F3-F7EA-4B4F-9BD3-252F198BF48E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B72A78F3-F7EA-4B4F-9BD3-252F198BF48E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F050DC6-8A35-4577-88DF-99F9193734D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F050DC6-8A35-4577-88DF-99F9193734D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F050DC6-8A35-4577-88DF-99F9193734D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F050DC6-8A35-4577-88DF-99F9193734D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F920BC5A-9BBF-40D4-BAAF-C22ADE187D12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F920BC5A-9BBF-40D4-BAAF-C22ADE187D12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F920BC5A-9BBF-40D4-BAAF-C22ADE187D12}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F920BC5A-9BBF-40D4-BAAF-C22ADE187D12}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,6 +82,7 @@ Global
 		{8C217C66-125B-441F-9FC5-EAAAB8A43EF9} = {292DA52B-60C9-4358-A1EE-265039ED8FE4}
 		{9AA8A6D5-E83C-4F39-A6D0-C7CECE89F87A} = {248C76AE-EECF-4AA1-8319-B506B14E30E4}
 		{5E5404D5-C965-4398-AEA5-F308B3700CF4} = {248C76AE-EECF-4AA1-8319-B506B14E30E4}
+		{F920BC5A-9BBF-40D4-BAAF-C22ADE187D12} = {292DA52B-60C9-4358-A1EE-265039ED8FE4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4084BC42-A8A9-4802-B482-664850C4D8AC}

--- a/demo/MvcDemo/Controllers/HomeController.cs
+++ b/demo/MvcDemo/Controllers/HomeController.cs
@@ -22,7 +22,9 @@ namespace MvcDemo.Controllers
             return View(new HomeViewModel()
             {
                 Markdown = System.IO.File.ReadAllText(
-                    Path.Combine(_hostEnvironment.WebRootPath, "..", "..", "..", "Pmad.Milsymbol.Markdig", "EXAMPLES.md")),
+                    Path.Combine(_hostEnvironment.WebRootPath, "..", "..", "..", "Pmad.Milsymbol.Markdig", "EXAMPLES.md")) +
+                    System.IO.File.ReadAllText(
+                    Path.Combine(_hostEnvironment.WebRootPath, "..", "..", "..", "Pmad.Milsymbol.Markdig", "QUICKREF.md")),
                 RootUnit = new OrbatUnitViewModel()
                 {
                     Sdic = "10031000150000000000",

--- a/demo/MvcDemo/Controllers/HomeController.cs
+++ b/demo/MvcDemo/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 using MvcDemo.Models;
 using Pmad.Milsymbol.AspNetCore.Orbat;
 
@@ -8,16 +9,20 @@ namespace MvcDemo.Controllers
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly IWebHostEnvironment _hostEnvironment;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, IWebHostEnvironment hostEnvironment)
         {
             _logger = logger;
+            _hostEnvironment = hostEnvironment;
         }
 
         public IActionResult Index()
         {
             return View(new HomeViewModel()
             {
+                Markdown = System.IO.File.ReadAllText(
+                    Path.Combine(_hostEnvironment.WebRootPath, "..", "..", "..", "Pmad.Milsymbol.Markdig", "EXAMPLES.md")),
                 RootUnit = new OrbatUnitViewModel()
                 {
                     Sdic = "10031000150000000000",

--- a/demo/MvcDemo/MarkdownToHtml.cs
+++ b/demo/MvcDemo/MarkdownToHtml.cs
@@ -1,7 +1,7 @@
 ﻿using Markdig;
 using Pmad.Milsymbol.Markdig;
 
-namespace MvcDemoBS5
+namespace MvcDemo
 {
     public static class MarkdownToHtml
     {

--- a/demo/MvcDemo/MarkdownToHtml.cs
+++ b/demo/MvcDemo/MarkdownToHtml.cs
@@ -1,0 +1,17 @@
+﻿using Markdig;
+using Pmad.Milsymbol.Markdig;
+
+namespace MvcDemoBS5
+{
+    public static class MarkdownToHtml
+    {
+        public static string ConvertMarkdownToHtml (string markdown)
+        {
+            var pipeline = new Markdig.MarkdownPipelineBuilder()
+                .UseAdvancedExtensions()
+                .UseMilsymbol() // Use the custom Milsymbol extension
+                .Build();
+            return Markdig.Markdown.ToHtml(markdown, pipeline);
+        }
+    }
+}

--- a/demo/MvcDemo/Models/HomeViewModel.cs
+++ b/demo/MvcDemo/Models/HomeViewModel.cs
@@ -11,5 +11,6 @@ namespace MvcDemo.Models
         public string? Symbol2 { get; set; }
         public string? Symbol3 { get; set; }
 
+        public string Markdown { get; set; } = string.Empty;
     }
 }

--- a/demo/MvcDemo/MvcDemoBS5.csproj
+++ b/demo/MvcDemo/MvcDemoBS5.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Pmad.Milsymbol.AspNetCore\Pmad.Milsymbol.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Pmad.Milsymbol.Markdig\Pmad.Milsymbol.Markdig.csproj" />
   </ItemGroup>
 
 </Project>

--- a/demo/MvcDemo/Views/Home/Index.cshtml
+++ b/demo/MvcDemo/Views/Home/Index.cshtml
@@ -19,6 +19,10 @@
 
 <pmad-orbat root-unit="@Model.RootUnit" />
 
+<h2>Sample Markdown</h2>
+
+@Html.Raw(MvcDemoBS5.MarkdownToHtml.ConvertMarkdownToHtml(Model.Markdown))
+
 @section Scripts {
     <script>
         document.addEventListener("DOMContentLoaded", function(){

--- a/demo/MvcDemo/Views/Home/Index.cshtml
+++ b/demo/MvcDemo/Views/Home/Index.cshtml
@@ -21,7 +21,7 @@
 
 <h2>Sample Markdown</h2>
 
-@Html.Raw(MvcDemoBS5.MarkdownToHtml.ConvertMarkdownToHtml(Model.Markdown))
+@Html.Raw(MvcDemo.MarkdownToHtml.ConvertMarkdownToHtml(Model.Markdown))
 
 @section Scripts {
     <script>

--- a/demo/MvcDemoBS4/MvcDemoBS4.csproj
+++ b/demo/MvcDemoBS4/MvcDemoBS4.csproj
@@ -10,10 +10,12 @@
     <Compile Include="..\MvcDemo\Controllers\HomeController.cs" Link="Controllers\HomeController.cs" />
     <Compile Include="..\MvcDemo\Models\ErrorViewModel.cs" Link="Models\ErrorViewModel.cs" />
     <Compile Include="..\MvcDemo\Models\HomeViewModel.cs" Link="Models\HomeViewModel.cs" />
+	<Compile Include="..\MvcDemo\MarkdownToHtml.cs" Link="MarkdownToHtml.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Pmad.Milsymbol.AspNetCore\Pmad.Milsymbol.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\Pmad.Milsymbol.Markdig\Pmad.Milsymbol.Markdig.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR introduce a Markdig extension that allows rendering military symbols (SVG) directly in Markdown documents.

# Usage

```csharp
using Markdig;
using Pmad.Milsymbol.Markdig;

var pipeline = new MarkdownPipelineBuilder()
    .UseMilsymbol()
    .Build();

var markdown = "Friend Infantry: :ms[10031000131211050000]:";
var html = Markdown.ToHtml(markdown, pipeline);
```
# Syntax

The extension adds an inline syntax for military symbols:

```
:ms[SIDC]:
```

Where `SIDC` is a valid Symbol Identification Code (20 or 30 digits).

# Options Syntax

You can specify rendering options as comma-separated key-value pairs within the brackets:

```
:ms[SIDC, key1=value1, key2=value2]:
```

# Examples

**Basic symbols:**
```markdown
# Military Symbols Demo

This is a friend infantry unit: :ms[10031000131211050000]:

This is an enemy armor unit: :ms[10061000161211000000]:

You can use symbols inline in text, in lists:
- Friend: :ms[10031000131211050000]:
- Enemy: :ms[10061000161211000000]:

Or in tables:
| Unit | Symbol |
|------|--------|
| Infantry | :ms[10031000131211050000]: |
| Armor | :ms[10061000161211000000]: |
```

**Symbols with options (long form):**
```markdown
# Unit Roster

## Alpha Company

- **A-1 Platoon** (Ready): :ms[10031000131211050000, uniqueDesignation="A-1", additionalInformation="Ready", higherFormation="ALPHA"]:
- **A-2 Platoon** (Moving NE): :ms[10031000131211050000, uniqueDesignation="A-2", direction=45]:
- **Large symbol**: :ms[10031000131211050000, size=50, uniqueDesignation="HQ"]:

## Bravo Company

Enemy contact: :ms[10061000161211000000, uniqueDesignation="HOSTILE", additionalInformation="Engaged"]:
```

**Symbols with options (short form):**
```markdown
# Unit Roster

## Alpha Company

- **A-1 Platoon** (Ready): :ms[10031000131211050000, ud="A-1", ai="Ready", hf="ALPHA"]:
- **A-2 Platoon** (Moving NE): :ms[10031000131211050000, ud="A-2", d=45]:
- **Large symbol**: :ms[10031000131211050000, s=50, ud="HQ"]:

## Bravo Company

Enemy contact: :ms[10061000161211000000, ud="HOSTILE", ai="Engaged"]:
```

**Custom sizing:**
```markdown
Small: :ms[10031000131211050000, size=20]:
Medium: :ms[10031000131211050000, size=30]:
Large: :ms[10031000131211050000, size=50]:

Or using short form:
Small: :ms[10031000131211050000, s=20]:
Medium: :ms[10031000131211050000, s=30]:
Large: :ms[10031000131211050000, s=50]:
```